### PR TITLE
Update Cloudbuild to set BaseURL

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -110,8 +110,19 @@ steps:
         "https://storage.googleapis.com/${_BUCKET_NAME}",
       ]
     dir: "./deploy"
+    # SET BASE URL
+  - id: "apply_base_url"
+    waitFor:
+      - "build_client"
+    name: gcr.io/cloud-builders/gcloud
+    entrypoint: /bin/bash
+    dir: "client/dist"
+    args:
+      - "-c"
+      - |-
+        sed -i "s/base href=\"\/\"/base href=\"$_BASEURL\"/g" index.html
   - id: "deploy_client"
-    waitFor: ["fix_client_asset_paths"]
+    waitFor: ["fix_client_asset_paths", "apply_base_url"]
     name: gcr.io/cloud-builders/gsutil
     args: ["-m", "rsync", "-r", "-c", "-d", "./dist", "gs://${_BUCKET_NAME}"]
     dir: "./client"


### PR DESCRIPTION
Adds a step in build that uses `sed` to replace the base value
with a Cloud Build Substitution value