### PR TITLE
Be proactive in getting the tree images and svg icons

### DIFF
--- a/client/ngsw-config.json
+++ b/client/ngsw-config.json
@@ -11,7 +11,9 @@
           "/index.html",
           "/manifest.webmanifest",
           "/*.css",
-          "/*.js"
+          "/*.js",
+          "/assets/img/**",
+          "/assets/icons/**"
         ]
       }
     },


### PR DESCRIPTION
This isn't too intensive as there aren't too many images. It will
resolve an issue where when you navigate for the first time, you
don't see the icons straight away because the service worker
has taken control of the network collections and is currently
lazy fetching.

I've deemed these priority assets for the app, everthing else will
still be lazy fetched.

Closes #182