### PR TITLE
Allow index.html to have a different cache time than default

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -58,6 +58,7 @@ steps:
       - ${_APP_SERVICE}
       - "../server/app.yaml"
       - ${_APP_CACHE}
+      - ${_INDEX_CACHE}
       - "../server/dispatch.yaml"
       - ${_PROD_URL}
       - ${_STAGING_URL}

--- a/deploy/configure_server.js
+++ b/deploy/configure_server.js
@@ -3,10 +3,14 @@ const path = require('path');
 
 const APP_SERVICE = process.argv[2];
 const APP_YAML_PATH = process.argv[3];
+// The time for all static assets max-age
 const APP_CACHE_TIME = process.argv[4];
-const DISPATCH_YAML_PATH = process.argv[5];
-const PROD_URL = process.argv[6];
-const STAGING_URL = process.argv[7];
+// the time for index.html to expire, generally this will be shorter than
+// the static assets
+const INDEX_CACHE_TIME = process.argv[5];
+const DISPATCH_YAML_PATH = process.argv[6];
+const PROD_URL = process.argv[7];
+const STAGING_URL = process.argv[8];
 
 
 if (!APP_YAML_PATH) {
@@ -20,8 +24,10 @@ if (!APP_CACHE_TIME) {
 if (APP_SERVICE) {
     const appYamlPath = path.join(process.cwd(), APP_YAML_PATH);
     let appYamlContent = fs.readFileSync(appYamlPath, { encoding: 'utf-8' });
+
     appYamlContent = appYamlContent.replace('$SERVICE', APP_SERVICE);
     appYamlContent = appYamlContent.replace('$CACHE', APP_CACHE_TIME);
+    appYamlContent = appYamlContent.replace('$INDEX_CACHE', INDEX_CACHE_TIME);
     fs.writeFileSync(appYamlPath, appYamlContent);
 
     // Prepare the dispach.yaml

--- a/server/app.yaml
+++ b/server/app.yaml
@@ -71,6 +71,7 @@ handlers:
     static_files: index.html
     upload: index.html
     secure: always
+    expiration: $INDEX_CACHE
     http_headers:
       X-Frame-Options: "DENY"
       Strict-Transport-Security: "max-age=2592000; includeSubdomains"


### PR DESCRIPTION
Adds `_INDEX_CACHE` substitution to cloud build config and this is passed along to `configure_server.js`

Relates to #199